### PR TITLE
feat: add CI/CD workflows

### DIFF
--- a/.github/workflows/ai-cd.yml
+++ b/.github/workflows/ai-cd.yml
@@ -1,0 +1,189 @@
+# AI Server CD Pipeline
+# 위치: .github/workflows/ai-cd.yml
+#
+# 트리거: 수동 (workflow_dispatch)
+# 인증: GCP Workload Identity Federation (OIDC)
+# 배포: In-place 배포 (VM 직접 업데이트)
+
+name: AI Server CD
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: '배포를 진행하시겠습니까? (yes 입력)'
+        required: true
+        type: string
+
+env:
+  PYTHON_VERSION: "3.10"
+  GCP_PROJECT_ID: "fiery-topic-483322-b2"
+  GCP_ZONE: "asia-northeast3-b"
+  GCP_INSTANCE: "ai-server"
+  WORKLOAD_IDENTITY_PROVIDER: "projects/7174586152/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
+  SERVICE_ACCOUNT: "github-actions-sa@fiery-topic-483322-b2.iam.gserviceaccount.com"
+
+jobs:
+  # ============================================
+  # Validation
+  # ============================================
+  validate:
+    name: Validate Input
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check Confirmation
+        if: ${{ github.event.inputs.confirm != 'yes' }}
+        run: |
+          echo "배포가 취소되었습니다. 'yes'를 입력해주세요."
+          exit 1
+
+  # ============================================
+  # Deploy
+  # ============================================
+  deploy:
+    name: Deploy to GCP
+    runs-on: ubuntu-22.04
+    needs: validate
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP (OIDC)
+        id: auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
+
+      - name: Setup gcloud CLI
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID }}
+
+      - name: Download Latest Artifact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # 최신 성공한 CI run에서 artifact 다운로드
+          mkdir -p ./artifact
+
+          # main 브랜치의 최신 성공한 워크플로우 실행 찾기
+          RUN_ID=$(gh run list \
+            --workflow="AI Server CI" \
+            --branch=main \
+            --status=success \
+            --limit=1 \
+            --json databaseId \
+            --jq '.[0].databaseId')
+
+          if [ -z "$RUN_ID" ]; then
+            echo "No successful CI run found"
+            exit 1
+          fi
+
+          echo "Downloading artifact from run: $RUN_ID"
+          gh run download "$RUN_ID" --dir ./artifact
+
+      - name: Find Artifact File
+        id: artifact
+        run: |
+          ARTIFACT_FILE=$(find ./artifact -name "*.tar.gz" | head -1)
+          if [ -z "$ARTIFACT_FILE" ]; then
+            echo "Artifact not found"
+            exit 1
+          fi
+          echo "file=$ARTIFACT_FILE" >> $GITHUB_OUTPUT
+          echo "Artifact found: $ARTIFACT_FILE"
+
+      - name: Upload Artifact to VM
+        run: |
+          gcloud compute scp ${{ steps.artifact.outputs.file }} \
+            ${{ env.GCP_INSTANCE }}:/tmp/ai-server-deploy.tar.gz \
+            --zone=${{ env.GCP_ZONE }}
+
+      - name: Deploy on VM
+        run: |
+          gcloud compute ssh ${{ env.GCP_INSTANCE }} \
+            --zone=${{ env.GCP_ZONE }} \
+            --command='
+              set -e
+
+              # 백업 생성
+              BACKUP_DIR="/app/ai-server-backup-$(date +%Y%m%d%H%M%S)"
+              if [ -d "/app/ai-server" ]; then
+                sudo cp -r /app/ai-server "$BACKUP_DIR"
+                echo "Backup created: $BACKUP_DIR"
+              fi
+
+              # 서비스 중단
+              sudo systemctl stop ai-server || true
+              echo "Service stopped"
+
+              # 배포
+              sudo mkdir -p /app/ai-server
+              sudo tar -xzf /tmp/ai-server-deploy.tar.gz -C /app/ai-server
+              sudo chown -R jsh:jsh /app/ai-server
+              echo "Artifact deployed"
+
+              # 서비스 시작
+              sudo systemctl start ai-server
+              echo "Service started"
+
+              # 임시 파일 정리
+              rm -f /tmp/ai-server-deploy.tar.gz
+            '
+
+      - name: Health Check
+        id: healthcheck
+        run: |
+          # VM 외부 IP 조회
+          EXTERNAL_IP=$(gcloud compute instances describe ${{ env.GCP_INSTANCE }} \
+            --zone=${{ env.GCP_ZONE }} \
+            --format='get(networkInterfaces[0].accessConfigs[0].natIP)')
+
+          echo "Health check started: http://$EXTERNAL_IP:8000/health"
+
+          # 최대 60초 대기 (5초 간격, 12회 시도)
+          for i in {1..12}; do
+            if curl -s -f "http://$EXTERNAL_IP:8000/health" > /dev/null; then
+              echo "Health check passed"
+              echo "status=success" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+            echo "Attempt $i/12 - Waiting for server..."
+            sleep 5
+          done
+
+          echo "Health check failed"
+          echo "status=failed" >> $GITHUB_OUTPUT
+          exit 1
+
+      - name: Rollback on Failure
+        if: failure() && steps.healthcheck.outputs.status == 'failed'
+        run: |
+          gcloud compute ssh ${{ env.GCP_INSTANCE }} \
+            --zone=${{ env.GCP_ZONE }} \
+            --command='
+              set -e
+
+              # 최신 백업 찾기
+              LATEST_BACKUP=$(ls -td /app/ai-server-backup-* 2>/dev/null | head -1)
+
+              if [ -n "$LATEST_BACKUP" ]; then
+                echo "Rollback started: $LATEST_BACKUP"
+
+                sudo systemctl stop ai-server || true
+                sudo rm -rf /app/ai-server
+                sudo mv "$LATEST_BACKUP" /app/ai-server
+                sudo systemctl start ai-server
+
+                echo "Rollback completed"
+              else
+                echo "Backup not found"
+                exit 1
+              fi
+            '

--- a/.github/workflows/ai-ci.yml
+++ b/.github/workflows/ai-ci.yml
@@ -1,0 +1,183 @@
+# AI Server CI Pipeline
+# 위치: .github/workflows/ai-ci.yml
+#
+# 트리거 매트릭스:
+#   - PR feat/* → dev: lint, test
+#   - Push dev: lint, test, build
+#   - PR dev/hotfix/* → main: lint, test, build
+#   - Push main: artifact
+
+name: AI Server CI
+
+on:
+  push:
+    branches: [main, dev]
+    paths-ignore:
+      - '.github/workflows/**'
+      - '**.md'
+      - 'docs/**'
+  pull_request:
+    branches: [main, dev]
+    paths-ignore:
+      - '.github/workflows/**'
+      - '**.md'
+      - 'docs/**'
+
+env:
+  PYTHON_VERSION: "3.10"
+
+jobs:
+  # ============================================
+  # Lint (Ruff)
+  # ============================================
+  lint:
+    name: Lint
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Ruff
+        run: pip install ruff
+
+      - name: Run Ruff Linter
+        run: ruff check .
+
+      - name: Run Ruff Formatter Check
+        run: ruff format --check .
+
+  # ============================================
+  # Test (pytest)
+  # ============================================
+  test:
+    name: Test
+    runs-on: ubuntu-22.04
+    needs: lint
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          pip install pytest pytest-cov
+
+      - name: Run Tests
+        run: |
+          if [ -d "tests" ]; then
+            pytest tests/ -v --cov=. --cov-report=xml
+          else
+            echo "No tests directory found, skipping tests"
+          fi
+
+  # ============================================
+  # Build
+  # dev push, main PR에서만 실행 (main push 제외)
+  # ============================================
+  build:
+    name: Build
+    runs-on: ubuntu-22.04
+    needs: test
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/dev') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Verify Build
+        run: |
+          # Python 문법 검증
+          python -m py_compile $(find . -name "*.py" -not -path "./.venv/*" -not -path "./venv/*" 2>/dev/null || echo "")
+          echo "Build verification completed"
+
+  # ============================================
+  # Upload Artifact
+  # main push에서만 실행
+  # ============================================
+  artifact:
+    name: Upload Artifact
+    runs-on: ubuntu-22.04
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: 'pip'
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Create Artifact
+        run: |
+          mkdir -p dist
+          # 소스코드 패키징
+          tar -czvf dist/ai-server-${{ github.sha }}.tar.gz \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='__pycache__' \
+            --exclude='.pytest_cache' \
+            --exclude='.ruff_cache' \
+            --exclude='*.pyc' \
+            --exclude='venv' \
+            --exclude='.venv' \
+            .
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ai-server-${{ github.sha }}
+          path: dist/
+          retention-days: 7
+
+  # ============================================
+  # Discord Notification (Optional)
+  # ============================================
+  # notify:
+  #   name: Discord Notification
+  #   runs-on: ubuntu-22.04
+  #   needs: [lint, test, build]
+  #   if: always() && (needs.lint.result == 'failure' || needs.test.result == 'failure' || needs.build.result == 'failure')
+  #   steps:
+  #     - name: Discord Notification
+  #       uses: sarisia/actions-status-discord@v1
+  #       with:
+  #         webhook: ${{ secrets.DISCORD_WEBHOOK }}
+  #         title: "AI Server CI 실패"
+  #         description: |
+  #           **Branch**: ${{ github.ref_name }}
+  #           **Commit**: ${{ github.event.head_commit.message || github.event.pull_request.title }}
+  #           **Author**: ${{ github.actor }}
+  #         color: 0xff0000
+  #         username: "GitHub Actions"


### PR DESCRIPTION
## Summary
- AI 서버용 CI/CD 워크플로우 추가
- Ruff linter 설정 파일 추가

## 추가 파일
| 파일 | 설명 |
|------|------|
| `.github/workflows/ai-ci.yml` | CI 파이프라인 (lint, test, build, artifact) |
| `.github/workflows/ai-cd.yml` | CD 파이프라인 (GCP OIDC 기반 수동 배포) |
| `ruff.toml` | Python linter/formatter 설정 |

## CI 트리거
- PR → dev/main: lint, test
- Push dev: lint, test, build
- Push main: lint, test, artifact 업로드

## Test plan
- [ ] PR 생성 시 CI 워크플로우 자동 실행 확인