### PR TITLE
fix: CD 배포 시 venv 자동 설정 추가

### DIFF
--- a/.github/workflows/ai-cd.yml
+++ b/.github/workflows/ai-cd.yml
@@ -129,6 +129,16 @@ jobs:
               sudo chown -R jsh:jsh /app/ai-server
               echo "Artifact deployed"
 
+              # venv 생성 및 dependencies 설치
+              cd /app/ai-server
+              if [ ! -d "venv" ]; then
+                python3 -m venv venv
+                echo "venv created"
+              fi
+              /app/ai-server/venv/bin/pip install --upgrade pip -q
+              /app/ai-server/venv/bin/pip install -r requirements.txt -q
+              echo "Dependencies installed"
+
               # 서비스 시작
               sudo systemctl start ai-server
               echo "Service started"


### PR DESCRIPTION
## Summary
- CD 워크플로우에서 배포 시 venv 생성 및 dependencies 자동 설치 추가

## Changes
- venv 디렉토리 없으면 자동 생성
- pip 업그레이드 및 requirements.txt 설치

## Test plan
- CD 워크플로우 수동 실행하여 헬스체크 통과 확인