### PR TITLE
fix(cd): use dynamic user for chown

### DIFF
--- a/.github/workflows/ai-cd.yml
+++ b/.github/workflows/ai-cd.yml
@@ -129,7 +129,7 @@ jobs:
               fi
 
               # 권한 설정
-              sudo chown -R jsh:jsh /app/ai-server
+              sudo chown -R $(whoami):$(whoami) /app/ai-server
 
               # 서비스 시작
               sudo systemctl start ai-server


### PR DESCRIPTION
chown에서 하드코딩된 jsh 대신 $(whoami) 사용