### PR TITLE
feat(cd): add dynamic firewall rule for runner IP

### DIFF
--- a/.github/workflows/ai-cd.yml
+++ b/.github/workflows/ai-cd.yml
@@ -43,6 +43,20 @@ jobs:
         with:
           project_id: ${{ env.GCP_PROJECT_ID }}
 
+      - name: Get Runner IP
+        id: ip
+        run: echo "ip=$(curl -s ifconfig.me)" >> $GITHUB_OUTPUT
+
+      - name: Add Firewall Rule
+        run: |
+          gcloud compute firewall-rules create github-actions-temp-${{ github.run_id }} \
+            --allow=tcp:22 \
+            --source-ranges=${{ steps.ip.outputs.ip }}/32 \
+            --target-tags=ai-server \
+            --project=${{ env.GCP_PROJECT_ID }} \
+            --description="Temporary rule for GitHub Actions CD"
+          echo "Firewall rule created for IP: ${{ steps.ip.outputs.ip }}"
+
       - name: Download Artifact
         id: artifact
         env:
@@ -182,3 +196,11 @@ jobs:
                 exit 1
               fi
             '
+
+      - name: Remove Firewall Rule
+        if: always()
+        run: |
+          gcloud compute firewall-rules delete github-actions-temp-${{ github.run_id }} \
+            --project=${{ env.GCP_PROJECT_ID }} \
+            --quiet || true
+          echo "Firewall rule removed"


### PR DESCRIPTION
## Summary
- CD 실행 시 GitHub Actions runner IP를 GCP 방화벽에 임시 추가
- 배포 완료 후 방화벽 규칙 자동 제거

## Changes
1. Runner public IP 획득 (`ifconfig.me`)
2. 임시 방화벽 규칙 생성 (`github-actions-temp-{run_id}`)
3. 배포 완료 후 규칙 삭제 (`if: always()`)