### PR TITLE
refactor: print문을 logger로 전환

### DIFF
--- a/app/services/callback_service.py
+++ b/app/services/callback_service.py
@@ -1,6 +1,9 @@
+import logging
 from typing import Any
 
 import httpx
+
+logger = logging.getLogger(__name__)
 
 
 class CallbackService:
@@ -10,16 +13,16 @@ class CallbackService:
         self.token = token
 
     async def post_checklist_complete(self, case_id: str, payload: dict[str, Any]) -> None:
-        print("체크리스트 콜백 시작")
+        logger.info("체크리스트 콜백 시작", extra={"case_id": case_id})
         url = f"{self.base_url}/internal/callbacks/checklists/{case_id}/complete"
         headers = {"Content-Type": "application/json"}
         if self.token:
             headers["Authorization"] = f"Bearer {self.token}"
-        print("체크리스트 콜백 json: ", payload)
+        logger.info("체크리스트 콜백 전송", extra={"case_id": case_id, "payload": payload})
 
         res = await self.http.post(url, json=payload, headers=headers)
         res.raise_for_status()
-        print("체크리스트 콜백 성공")
+        logger.info("체크리스트 콜백 성공", extra={"case_id": case_id})
 
     async def post_easy_contract_markdown(self, case_id: int, markdown: str) -> None:
         url = f"{self.base_url}/internal/callbacks/easy-contracts/{case_id}/complete"


### PR DESCRIPTION
## Summary
- 24개 print문을 logger.info()/logger.debug()로 전환
- JSON 포맷 로깅 통일을 위한 구조화된 로깅 적용
- 대량 텍스트는 debug 레벨 + 메타데이터로 처리

## 변경 파일
- `app/services/easy_contract_service.py` (18개)
- `app/services/checklist_service.py` (3개)
- `app/services/callback_service.py` (3개)

## Test plan
- [ ] 로컬에서 API 호출 후 JSON 로그 포맷 확인
- [ ] 기존 기능 정상 동작 확인