### PR TITLE
fix(logging): app 로거 핸들러 설정 추가

### DIFF
--- a/app/logging_config.py
+++ b/app/logging_config.py
@@ -110,3 +110,11 @@ def setup_json_logging() -> None:
         logger.setLevel(log_level)
         for handler in handlers:
             logger.addHandler(handler)
+
+    # === app 로거 설정 (서비스 로거 포함) ===
+    # app.services.*, app.api.* 등 모든 하위 로거에 핸들러 적용
+    app_logger = logging.getLogger("app")
+    app_logger.handlers.clear()
+    app_logger.setLevel(log_level)
+    for handler in handlers:
+        app_logger.addHandler(handler)


### PR DESCRIPTION
## Summary
- app.* 네임스페이스 로거가 명시적으로 설정되지 않아 Loki에서 로그 미수집 문제 해결
- app 로거에 JSON 핸들러 직접 할당하여 하위 로거(app.services.* 등) 포함

## Test plan
- [ ] 배포 후 Loki에서 `{app="dojangkok-ai"} |= "체크리스트"` 쿼리로 로그 확인